### PR TITLE
Reduce bandwidth usage from unoptimized images

### DIFF
--- a/components/ui/layout-grid.tsx
+++ b/components/ui/layout-grid.tsx
@@ -1,8 +1,8 @@
 "use client";
-import React, { useState } from "react";
+import React, { forwardRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
-import Image, { StaticImageData } from "next/image";
+import Image, { ImageProps, StaticImageData } from "next/image";
 
 type Card = {
   id: number;
@@ -60,8 +60,10 @@ export const LayoutGrid = ({ cards }: { cards: Card[] }) => {
 };
 
 const ImageComponent = ({ card }: { card: Card }) => {
+  const MotionImage = motion.create(forwardRef<HTMLImageElement, ImageProps>((props, ref) => <Image {...props} ref={ref} />));
+
   return (
-    <motion.img
+    <MotionImage
       layoutId={`image-${card.id}-image`}
       src={typeof card.thumbnail === 'string' ? card.thumbnail : card.thumbnail.src} // Handle both types
       height="500"


### PR DESCRIPTION
I saw your high Vercel bill on X. Some images are not using NextJS image optimization and is just serving the full unoptimized static image. 

This results in big bandwidth usage and much higher bandwidth costs serving these images from the edge.
![image](https://github.com/user-attachments/assets/d13f3671-8279-415c-b886-f057b37c5579)

The images that are causing a large majority of this bandwidth usage are the static unoptimized ones.
![image](https://github.com/user-attachments/assets/ef039252-6296-45ee-b00b-0f2cf7363543)

The changes are just wrapping the NextJS Image component in a custom Framer motion component, instead of just serving the static image with a ordinary img html element.